### PR TITLE
Temporarily disable competition link in NavBar

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -72,7 +72,7 @@ const NavBar = ({ height = "7rem" }) => {
           )}
           {createTab("/timeline", "Abakus Historie")}
           {createTab("/members", "Utnevnte")}
-          {createTab("/code-competition", "Kodekonkurranse")}
+          {/* createTab("/code-competition", "Kodekonkurranse") */}
         </Tabs>
         {!isVertical && displayMenu}
       </>


### PR DESCRIPTION
There is only test data on the page. So it shouldn't be linked to in prod.